### PR TITLE
Refactoring and added MatrixMask

### DIFF
--- a/include/hrzn/hrzn.h
+++ b/include/hrzn/hrzn.h
@@ -277,22 +277,22 @@ namespace hrzn {
 	}; // hRotation
 
 
-	struct IterableRect; // Forward declaration
+	struct IterableArea; // Forward declaration
 
-	struct Rect {
+	struct Area {
 
 		hType_i x1, y1, x2, y2;
 
-		Rect() : x1(0), y1(0), x2(0), y2(0) {}
+		Area() : x1(0), y1(0), x2(0), y2(0) {}
 
-		Rect(std::size_t w, std::size_t h) {
+		Area(std::size_t w, std::size_t h) {
 			x1 = 0;
 			y1 = 0;
 			x2 = (hType_i)w - 1;
 			y2 = (hType_i)h - 1;
 		}
 
-		Rect(hType_i x_1, hType_i y_1, hType_i x_2, hType_i y_2)
+		Area(hType_i x_1, hType_i y_1, hType_i x_2, hType_i y_2)
 		{
 			x1 = std::min(x_1, x_2);
 			x2 = std::max(x_1, x_2);
@@ -300,21 +300,21 @@ namespace hrzn {
 			y2 = std::max(y_1, y_2);
 		}
 
-		explicit Rect(hPoint pos, hPoint sz) {
+		explicit Area(hPoint pos, hPoint sz) {
 			x1 = pos.x;
 			y1 = pos.y;
 			x2 = pos.x + sz.x - 1;
 			y2 = pos.y + sz.y - 1;
 		}
 
-		IterableRect iterable();
+		IterableArea iterable();
 
-		Rect& operator +=(hPoint dist) {
+		Area& operator +=(hPoint dist) {
 			move(dist.x, dist.y);
 			return *this;
 		}
 
-		Rect& operator -=(hPoint dist) {
+		Area& operator -=(hPoint dist) {
 			move(-dist.x, -dist.y);
 			return *this;
 		}
@@ -352,8 +352,8 @@ namespace hrzn {
 			resize(ctr.x - w / 2, ctr.y - h / 2, x1 + w - 1, y1 + h - 1);
 		}
 
-		Rect normalize() {
-			return Rect(0, 0, x2 - x1, y2 - y1);
+		Area normalize() {
+			return Area(0, 0, x2 - x1, y2 - y1);
 		}
 
 		hPoint getClampedValue(const hPoint& pt) const {
@@ -418,13 +418,13 @@ namespace hrzn {
 			return x >= x1 && x <= x2 && y >= y1 && y <= y2;
 		}
 
-		/// Create a Rect object using position, width, and height.
-		static Rect build(hType_i x, hType_i y, hType_i width, hType_i height) {
-			return Rect(x, y, x + width - 1, y + height - 1);
+		/// Create a Area object using position, width, and height.
+		static Area build(hType_i x, hType_i y, hType_i width, hType_i height) {
+			return Area(x, y, x + width - 1, y + height - 1);
 		}
 
-		static Rect buildBoundary(std::initializer_list<hPoint> pts) {
-			Rect r (pts.begin()->x, pts.begin()->y, pts.begin()->x, pts.begin()->y);
+		static Area buildBoundary(std::initializer_list<hPoint> pts) {
+			Area r (pts.begin()->x, pts.begin()->y, pts.begin()->x, pts.begin()->y);
 			for (auto p : pts) {
 				r.x1 = std::min(r.x1, p.x);
 				r.y1 = std::min(r.y1, p.y);
@@ -434,17 +434,17 @@ namespace hrzn {
 			return r;
 		}
 
-		static Rect buildRadius(hType_i x, hType_i y, hType_i radius) {
-			return Rect(x - radius, y - radius, x + radius, y + radius);
+		static Area buildRadius(hType_i x, hType_i y, hType_i radius) {
+			return Area(x - radius, y - radius, x + radius, y + radius);
 		}
 
-		static Rect intersect(const Rect& a, const Rect& b) {
-			return Rect(std::max(a.x1, b.x1), std::max(a.y1, b.y1), std::min(a.x2, b.x2), std::min(a.y2, b.y2));
+		static Area intersect(const Area& a, const Area& b) {
+			return Area(std::max(a.x1, b.x1), std::max(a.y1, b.y1), std::min(a.x2, b.x2), std::min(a.y2, b.y2));
 		}
 
-	}; // struct Rect
+	}; // struct Area
 
-	struct IterableRect : public Rect {
+	struct IterableArea : public Area {
 
 		struct iterator : public hPoint {
 			using iterator_category = std::forward_iterator_tag;
@@ -483,7 +483,7 @@ namespace hrzn {
 			const hType_i m_w, m_x, m_y;
 		};
 
-		IterableRect(const Rect& _rect) : Rect(_rect) {}
+		IterableArea(const Area& _area) : Area(_area) {}
 
 		iterator begin() {
 			return iterator(0, width(), x1, y1);
@@ -495,8 +495,8 @@ namespace hrzn {
 
 	}; // struct IterableRect
 
-	IterableRect Rect::iterable() {
-		return IterableRect(*this);
+	IterableArea Area::iterable() {
+		return IterableArea(*this);
 	}
 
 
@@ -509,19 +509,19 @@ namespace hrzn {
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
 	template <typename T>
-	class IMatrix : public Rect {
+	class IMatrix : public Area {
 	public:
 
 		using fill_func = T(*)();
 		//using fill_func = std::function<T()>; // TODO add ifdef block to check for cpp compiler version
 
-		IMatrix(const Rect& rect) : Rect(rect) {}
+		IMatrix(const Area& area) : Area(area) {}
 
 		virtual ~IMatrix() {}
 
 		// Common inherited methods
 		Region<T> region();
-		Region<T> region(const Rect& area);
+		Region<T> region(const Area& area);
 
 		T& operator[](hPoint pt) { return at(pt.x, pt.y); }
 		T operator[](hPoint pt) const { return at(pt.x, pt.y); }
@@ -554,7 +554,7 @@ namespace hrzn {
 	/// </summary>
 	/// <typeparam name="T">Element Type of the reference Matrix</typeparam>
 	template<typename T>
-	class Region : public Rect {
+	class Region : public Area {
 
 	public:
 		struct RegionPoint : public hPoint {
@@ -573,12 +573,12 @@ namespace hrzn {
 
 		private:
 			IMatrix<T>* m_source;
-			Rect m_area;
+			Area m_area;
 			std::size_t m_index;
 			RegionPoint m_container;
 
 		public:
-			RegionIterator(IMatrix<T>* source, Rect area, std::size_t i = 0) : m_source(source), m_area(area), m_index(i) {
+			RegionIterator(IMatrix<T>* source, Area area, std::size_t i = 0) : m_source(source), m_area(area), m_index(i) {
 				m_container.x = m_area.x1 + (hType_i)m_index % m_area.width();
 				m_container.y = m_area.y1 + (hType_i)(m_index / m_area.width());
 				if (source && i != area.area())
@@ -626,8 +626,8 @@ namespace hrzn {
 		IMatrix<T>* m_source;
 
 	public:
-		Region(Rect area, IMatrix<T>* source) :
-			Rect(area), m_source(source) {}
+		Region(Area area, IMatrix<T>* source) :
+			Area(area), m_source(source) {}
 
 		RegionIterator begin() { return RegionIterator(m_source, *this, 0); }
 		RegionIterator end() { return RegionIterator(m_source, *this, this->area()); }
@@ -654,11 +654,11 @@ namespace hrzn {
 
 	public:
 
-		MatrixContainer() : base(Rect()) {}
-		MatrixContainer(std::size_t w, std::size_t h) : base(Rect(w, h)), m_contents(new T[w * h]) {}
-		MatrixContainer(std::size_t w, std::size_t h, const T& obj) : base(Rect(w, h)), m_contents(new T[w * h]) { for (auto& i : (*this)) i = obj; }
-		MatrixContainer(const Rect& rect) : base(rect), m_contents(new T[rect.area()]) {}
-		MatrixContainer(const Rect& rect, const T& obj) : base(rect), m_contents(new T[rect.area()]) { for (auto& i : (*this)) i = obj; }
+		MatrixContainer() : base(Area()) {}
+		MatrixContainer(std::size_t w, std::size_t h) : base(Area(w, h)), m_contents(new T[w * h]) {}
+		MatrixContainer(std::size_t w, std::size_t h, const T& obj) : base(Area(w, h)), m_contents(new T[w * h]) { for (auto& i : (*this)) i = obj; }
+		MatrixContainer(const Area& rect) : base(rect), m_contents(new T[rect.area()]) {}
+		MatrixContainer(const Area& rect, const T& obj) : base(rect), m_contents(new T[rect.area()]) { for (auto& i : (*this)) i = obj; }
 
 		MatrixContainer(const MatrixContainer<T>& other) : base(other), m_contents(new T[other.area()]) {
 			std::copy(other.m_contents, other.m_contents + other.area(), m_contents);
@@ -677,7 +677,7 @@ namespace hrzn {
 				delete[] m_contents;
 				m_contents = new T[other.area()];
 				std::copy(other.m_contents, other.m_contents + other.area(), m_contents);
-				Rect::resize(other.x1, other.y1, other.x2, other.y2);
+				Area::resize(other.x1, other.y1, other.x2, other.y2);
 			}
 			return *this;
 		}
@@ -706,16 +706,16 @@ namespace hrzn {
 
 		void resize(hType_i xa, hType_i ya, hType_i xb, hType_i yb, const T& fill_obj) {
 			assert(m_contents != nullptr);
-			Rect new_rect(xa, ya, xb, yb);
+			Area new_rect(xa, ya, xb, yb);
 				T* new_block = new T[new_rect.area()];
 				for (hType_i y = new_rect.y1; y <= new_rect.y2; ++y)
 					for (hType_i x = new_rect.x1; x <= new_rect.x2; ++x) {
 						hType_i i = (x - new_rect.x1) + (y - new_rect.y1) * (hType_i)new_rect.width();
-						new_block[i] = Rect::contains(x, y) ? std::move(m_contents[base::m_Index(x, y)]) : fill_obj;
+						new_block[i] = Area::contains(x, y) ? std::move(m_contents[base::m_Index(x, y)]) : fill_obj;
 					}
 				delete[]m_contents;
 				m_contents = new_block;
-			Rect::resize(new_rect.x1, new_rect.y1, new_rect.x2, new_rect.y2);
+			Area::resize(new_rect.x1, new_rect.y1, new_rect.x2, new_rect.y2);
 		}
 
 	}; // class MatrixContainer<T>
@@ -736,7 +736,7 @@ namespace hrzn {
 		using IMatrix<T>::set;
 		using base = IMatrix<T>;
 
-		SubMatrix(const Rect& area, base& mat) : base(area), m_source(&mat) {}
+		SubMatrix(const Area& area, base& mat) : base(area), m_source(&mat) {}
 
 		operator bool() const override { return m_source->operator bool(); }
 
@@ -751,8 +751,8 @@ namespace hrzn {
 		base* source() { return m_source; }
 		
 		void resize(hType_i xa, hType_i ya, hType_i xb, hType_i yb) override {
-			Rect new_rect = Rect::intersect(*this, { xa, ya, xb, yb });
-			Rect::resize(new_rect.x1, new_rect.y1, new_rect.x2, new_rect.y2);
+			Area new_rect = Area::intersect(*this, { xa, ya, xb, yb });
+			Area::resize(new_rect.x1, new_rect.y1, new_rect.x2, new_rect.y2);
 		}
 
 	}; // class SubMatrix<T>
@@ -780,12 +780,12 @@ namespace hrzn {
 
 	public:
 
-		MatrixMask(int w, int h) : base(Rect(w, h)), m_size((this->area() / c_bit_interval) + 1), m_blocks(new block_type[m_size]) {
+		MatrixMask(int w, int h) : base(Area(w, h)), m_size((this->area() / c_bit_interval) + 1), m_blocks(new block_type[m_size]) {
 			for (int i = 0; i < m_size; ++i)
 				m_blocks[i] = 0;
 		}
 
-		MatrixMask(Rect area) : base(Rect(area)), m_size((this->area() / c_bit_interval) + 1), m_blocks(new block_type[m_size]) {
+		MatrixMask(Area area) : base(Area(area)), m_size((this->area() / c_bit_interval) + 1), m_blocks(new block_type[m_size]) {
 			for (int i = 0; i < m_size; ++i)
 				m_blocks[i] = 0;
 		}
@@ -809,7 +809,7 @@ namespace hrzn {
 		MatrixMask& operator =(const IMatrix<bool>& other) {
 			if (this != &other) {
 				delete[] m_blocks;
-				Rect::resize(other.x1, other.y1, other.x2, other.y2);
+				Area::resize(other.x1, other.y1, other.x2, other.y2);
 				m_size = (other.area() / c_bit_interval) + 1;
 				m_blocks = new block_type[m_size];
 				for (int y = other.y1; y <= other.y2; ++y) {
@@ -824,7 +824,7 @@ namespace hrzn {
 		MatrixMask& operator =(const MatrixMask& other) {
 			if (this != &other) {
 				delete[] m_blocks;
-				Rect::resize(other.x1, other.y1, other.x2, other.y2);
+				Area::resize(other.x1, other.y1, other.x2, other.y2);
 				m_size = (other.area() / c_bit_interval) + 1;
 				m_blocks = new block_type[m_size];
 				std::copy(other.m_blocks, other.m_blocks + m_size, m_blocks);
@@ -853,12 +853,18 @@ namespace hrzn {
 		}
 
 		MatrixContainer<bool> expandedCopy() const {
-			MatrixContainer<bool> obj((Rect)*this);
+			MatrixContainer<bool> obj((Area)*this);
 			for (int y = obj.y1; y <= obj.y2; ++y)
 				for (int x = obj.x1; x <= obj.x2; ++x)
 					obj.set(x, y, this->at(x, y));
 			return obj;
 		}
+
+		void resize(hType_i xa, hType_i ya, hType_i xb, hType_i yb) override {
+			throw std::exception("MatrixMask::resize not implmemented.");
+			//resize(xa, ya, xb, yb, false);
+		}
+
 
 	private:
 		
@@ -875,7 +881,7 @@ namespace hrzn {
 
 	// Bitwise AND operation between two boolean Matrices
 	MatrixMask operator & (const IMatrix<bool>& a, const IMatrix<bool>& b) {
-		MatrixMask result(Rect::intersect(a, b));
+		MatrixMask result(Area::intersect(a, b));
 		for (int y = result.y1; y <= result.y2; ++y)
 			for (int x = result.x1; x <= result.x2; ++x)
 				result.set(x, y, a.at(x, y) && b.at(x, y));
@@ -884,7 +890,7 @@ namespace hrzn {
 
 	// Bitwise OR operation between two boolean Matrices
 	MatrixMask operator | (const IMatrix<bool>& a, const IMatrix<bool>& b) {
-		MatrixMask result(Rect::intersect(a, b));
+		MatrixMask result(Area::intersect(a, b));
 		for (int y = result.y1; y <= result.y2; ++y)
 			for (int x = result.x1; x <= result.x2; ++x)
 				result.set(x, y, a.at(x, y) || b.at(x, y));
@@ -893,7 +899,7 @@ namespace hrzn {
 
 	// Bitwise XOR operation between two boolean Matrices
 	MatrixMask operator ^ (const IMatrix<bool>& a, const IMatrix<bool>& b) {
-		MatrixMask result(Rect::intersect(a, b));
+		MatrixMask result(Area::intersect(a, b));
 		for (int y = result.y1; y <= result.y2; ++y)
 			for (int x = result.x1; x <= result.x2; ++x)
 				result.set(x, y, a.at(x, y) && b.at(x, y));
@@ -902,7 +908,7 @@ namespace hrzn {
 
 	// Bitwise Invert operation between on a boolean Matrix
 	MatrixMask operator ~ (const IMatrix<bool>& a) {
-		MatrixMask result((Rect)a);
+		MatrixMask result((Area)a);
 		for (int y = a.y1; y <= a.y2; ++y)
 			for (int x = a.x1; x <= a.x2; ++x)
 				result.set(x, y, !a.at(x, y));
@@ -912,12 +918,12 @@ namespace hrzn {
 
 	template<typename T>
 	inline Region<T> IMatrix<T>::region() {
-		return Region<T>(Rect(*this), this);
+		return Region<T>(Area(*this), this);
 	}
 
 	template<typename T>
-	inline Region<T> IMatrix<T>::region(const Rect& area) {
-		return Region<T>(Rect::intersect(*this, area), this);
+	inline Region<T> IMatrix<T>::region(const Area& area) {
+		return Region<T>(Area::intersect(*this, area), this);
 	}
 
 	template<typename T>

--- a/include/hrzn/hrzn.h
+++ b/include/hrzn/hrzn.h
@@ -503,8 +503,6 @@ namespace hrzn {
 	template <typename T>
 	class Region;
 
-	template <typename A, typename B>
-	class MatrixAccessor;
 
 	/// <summary>
 	/// Abstract class for all Matrix-like containers and accessors.
@@ -546,7 +544,6 @@ namespace hrzn {
 			throw std::out_of_range("invalid matrix index");
 		}
 	}; // class IMatrix<T>
-
 
 
 	/// <summary>
@@ -721,61 +718,9 @@ namespace hrzn {
 
 
 	/// <summary>
-	/// Helper class that can be used to access and iterate a single field from the container type.
+	/// A helper class used for operating on the sub region of an abstract Matrix parent class.
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
-	/// <typeparam name="TParent"></typeparam>
-	template <typename T, typename TParent>
-	class MatrixAccessor : public IMatrix<T> {
-	public:
-
-		using accessor = T TParent::*;
-
-		using IMatrix<T>::operator[];
-		using IMatrix<T>::at;
-		using base = IMatrix<T>;
-
-	private:
-		TParent** m_content_link = nullptr;
-		accessor m_accessor;
-
-	public:
-
-		MatrixAccessor(MatrixContainer<TParent>& mat, accessor access)
-			: base(mat), m_content_link(&mat.m_contents), m_accessor(access)
-		{}
-
-		operator bool() const override {
-			if (m_content_link) {
-				return *m_content_link;
-			}
-			return m_content_link;
-		}
-
-		T& at(hType_i x, hType_i y) override {
-			if (*m_content_link) {
-				return (*m_content_link)[base::m_Index(x, y)].*m_accessor;
-			}
-			throw std::runtime_error("source matrix has been deallocated");
-		}
-
-		const T& at(hType_i x, hType_i y) const override {
-			if (*m_content_link) {
-				return (*m_content_link)[base::m_Index(x, y)].*m_accessor;
-			}
-			throw std::runtime_error("source matrix has been deallocated");
-		}
-
-		void set(hType_i xa, hType_i ya, hType_i xb, hType_i yb) override {
-			throw std::runtime_error("MatrixView cannot be resized");
-		}
-
-	}; // class MatrixAccessor<T>
-
-
-	/**********************************************************************************************
-	 * \brief A helper class used for operating on the sub region of an abstract Matrix parent class.
-	**********************************************************************************************/
 	template <typename T>
 	class SubMatrix : public IMatrix<T> {
 	private:
@@ -799,9 +744,7 @@ namespace hrzn {
 	}; // class SubMatrix<T>
 
 
-	/**********************************************************************************************
-	 * \brief Type alias for \code MatrixContainer<bool>
-	**********************************************************************************************/
+	// Type alias for MatrixContainer<bool>
 	using Mask = MatrixContainer<bool>;
 
 

--- a/include/hrzn/stringify.h
+++ b/include/hrzn/stringify.h
@@ -52,12 +52,12 @@ namespace hrzn {
 		return input;
 	}
 
-	std::ostream& operator<<(std::ostream& output, const Rect& rect) {
+	std::ostream& operator<<(std::ostream& output, const Area& rect) {
 		output << rect.x1 << rect.y1 << rect.x2 << rect.y2;
 		return output;
 	}
 
-	std::istream& operator>>(std::istream& input, Rect& rect) {
+	std::istream& operator>>(std::istream& input, Area& rect) {
 		input >> rect.x1 >> rect.y1 >> rect.x2 >> rect.y2;
 		return input;
 	}
@@ -75,7 +75,7 @@ namespace hrzn {
 		return ss.str();
 	}
 
-	std::string toString(const Rect& rect) {
+	std::string toString(const Area& rect) {
 		std::stringstream ss;
 		ss << "Rect{" << rect.x1 << ',' << rect.y1 << ',' << rect.x2 << ',' << rect.y2 << '}';
 		return ss.str();
@@ -164,33 +164,31 @@ namespace hrzn {
 
 		std::stringstream ss;
 
-		int w = mat.width();
-		int h = mat.height();
 		int rail_pad = (int)(siding != 0);
 
 
 		if (top_line)
-			ss << makeStringLine((w + 1 + enumerate) * padding + rail_pad, top_line, corner, corner) << '\n';
+			ss << makeStringLine((mat.width() + enumerate) * padding + rail_pad, top_line, corner, corner) << '\n';
 
 		if (enumerate) {
 			ss << siding << std::setw(padding) << "";
-			for (int x = 0; x < h; x++)
+			for (int x = mat.x1; x < mat.x2; x++)
 				ss << std::setw(padding) << x;
 			ss << std::setw(padding) << siding << '\n';
 		}
 
-		for (int y = 0; y < w; y++) {
+		for (int y = mat.y1; y <= mat.y2; y++) {
 			ss << siding;
 			if (enumerate) {
 				ss << std::setw(padding) << y;
 			}
-			for (int x = 0; x < h; x++)
+			for (int x = mat.x1; x < mat.x2; x++)
 				ss << std::setw(padding) << mat.at(x, y);
 			ss << std::setw(padding) << siding << '\n';
 		}
 
 		if (bottom_line)
-			ss << makeStringLine((w + 1 + enumerate) * padding + rail_pad, bottom_line, corner, corner) << '\n';
+			ss << makeStringLine((mat.width() + enumerate) * padding + rail_pad, bottom_line, corner, corner) << '\n';
 
 		return ss.str();
 	}

--- a/include/hrzn/utility.h
+++ b/include/hrzn/utility.h
@@ -143,24 +143,33 @@ namespace hrzn {
 	******************************************************************************************************************/
 	
 	template <typename T>
-	void copy(IMatrix<T>& a, const IMatrix<T>& b) {
-		Rect area = hrzn::intersect(a, b);
+	void transfer(IMatrix<T>* to, const IMatrix<T>& from) {
+		Rect area = hrzn::intersect(*to, from);
 		for (int y = area.y1; y <= area.y2; ++y)
 			for (int x = area.x1; x <= area.x2; ++x)
-				a.at(x, y) = b.at(x, y);
+				to->at(x, y) = from.at(x, y);
+	}
+
+	template <typename Ta, typename Tb>
+	MatrixContainer<Ta> copy(const IMatrix<Tb>& mat, Ta(*cast)(Tb) = [](Tb val)->Ta {return static_cast<Ta>(val); }) {
+		MatrixContainer<Ta> dup(mat);
+		for (int y = mat.y1; y <= mat.y2; ++y)
+			for (int x = mat.x1; x <= mat.x2; ++x)
+				dup.at(x, y) = cast(mat.at(x, y));
+		return dup;
 	}
 
 	template <typename T>
-	void fill(IMatrix<T>& mat, const Rect area, const T& fill_obj) {
-		Rect fill_area = hrzn::intersect(mat, area);
+	void fill(IMatrix<T>* mat, const Rect area, const T& fill_obj) {
+		Rect fill_area = hrzn::intersect(*mat, area);
 		for (int y = fill_area.y1; y <= fill_area.y2; ++y)
 			for (int x = fill_area.x1; x <= fill_area.x2; ++x)
-				mat.at(x, y) = fill_obj;
+				mat->at(x, y) = fill_obj;
 	}
 
 	template <typename T>
-	void maskfill(IMatrix<T>& mat, const IMatrix<bool>& mask, const T& fill_obj) {
-		Rect fill_area = hrzn::intersect(mat, mask);
+	void maskfill(IMatrix<T>* mat, const IMatrix<bool>& mask, const T& fill_obj) {
+		Rect fill_area = hrzn::intersect(*mat, mask);
 		for (int y = fill_area.y1; y <= fill_area.y2; ++y)
 			for (int x = fill_area.x1; x <= fill_area.x2; ++x)
 				if (mask.at(x, y)) mat.at(x, y) = fill_obj;

--- a/include/hrzn/utility.h
+++ b/include/hrzn/utility.h
@@ -52,13 +52,13 @@ namespace hrzn {
 		Tuple Operations
 	******************************************************************************************************************/
 
-	hPoint wrapPoint(const hPoint& p, const Rect& area) {
+	hPoint wrapPoint(const hPoint& p, const Area& area) {
 		hType_i x = std::min(std::max(p.x, area.x1), area.x2);
 		hType_i y = std::min(std::max(p.y, area.y1), area.y2);
 		return { x, y };
 	}
 
-	hPoint clampPoint(const hPoint& p, const Rect& area) {
+	hPoint clampPoint(const hPoint& p, const Area& area) {
 		hType_i x = (p.x % area.width() + area.width()) % area.width();
 		hType_i y = (p.y % area.height() + area.height()) % area.height();
 		return { x, y };
@@ -94,28 +94,28 @@ namespace hrzn {
 		Area Operations
 	******************************************************************************************************************/
 
-	bool overlapping(const Rect& a, const Rect& b) {
+	bool overlapping(const Area& a, const Area& b) {
 		return !(a.x1 > b.x2 || a.y1 > b.y2 || b.x1 > a.x2 || b.y1 > a.y2);
 	}
 
-	bool contains(const Rect& a, const Rect& b) {
+	bool contains(const Area& a, const Area& b) {
 		return b.x1 >= a.x1 && b.y1 >= a.y1 && b.x2 <= a.x2 && b.y2 <= a.x2;
 	}
 
-	bool contains(const Rect& a, const hPoint& b) {
+	bool contains(const Area& a, const hPoint& b) {
 		return b.x >= a.x1 && b.y >= a.y1 && b.x <= a.x2 && b.y <= a.x2;
 	}
 
-	bool isEdgePoint(const Rect& rec, const hPoint& pos) {
+	bool isEdgePoint(const Area& rec, const hPoint& pos) {
 		return pos.x == rec.x1 || pos.x == rec.x2 || pos.y == rec.y1 || pos.y == rec.y2;
 	}
 
-	Rect intersect(const Rect& a, const Rect& b) {
-		return Rect(std::max(a.x1, b.x1), std::max(a.y1, b.y1), std::min(a.x2, b.x2), std::min(a.y2, b.y2));
+	Area intersect(const Area& a, const Area& b) {
+		return Area(std::max(a.x1, b.x1), std::max(a.y1, b.y1), std::min(a.x2, b.x2), std::min(a.y2, b.y2));
 	}
 
-	Rect makeBoundary(const Rect& a, const Rect& b) {
-		return Rect(std::min(a.x1, b.x1), std::min(a.y1, b.y1), std::max(a.x2, b.x2), std::max(a.y2, b.y2));
+	Area makeBoundary(const Area& a, const Area& b) {
+		return Area(std::min(a.x1, b.x1), std::min(a.y1, b.y1), std::max(a.x2, b.x2), std::max(a.y2, b.y2));
 	}
 
 	/// <summary>
@@ -123,19 +123,19 @@ namespace hrzn {
 	/// </summary>
 	/// <param name="rec">The <type>Urect</type> area to be split</param>
 	/// <returns>A container with the new URect objects. If <paramref name="rec"/> is only a single cell (width and height are equal to 1), then both are simply a copy of the orignal parameter. </returns>
-	std::pair<Rect, Rect> split(const Rect& rec) {
-		Rect r1 = rec;
-		Rect r2 = rec;
-		hPoint cp = rec.center();
-		if (rec.height() > 1 && rec.height() > rec.width()) {
-			r1.y2 = cp.y;
-			r2.y1 = cp.y + 1;
+	std::pair<Area, Area> split(const Area& area) {
+		Area a1 = area;
+		Area a2 = area;
+		hPoint cp = area.center();
+		if (area.height() > 1 && area.height() > area.width()) {
+			a1.y2 = cp.y;
+			a2.y1 = cp.y + 1;
 		}
-		else if (rec.width() > 1) {
-			r1.x2 = cp.x;
-			r2.x1 = cp.x + 1;
+		else if (area.width() > 1) {
+			a1.x2 = cp.x;
+			a2.x1 = cp.x + 1;
 		}
-		return std::make_pair(r1, r2);
+		return std::make_pair(a1, a2);
 	}
 
 	/******************************************************************************************************************
@@ -144,7 +144,7 @@ namespace hrzn {
 	
 	template <typename T>
 	void transfer(IMatrix<T>* to, const IMatrix<T>& from) {
-		Rect area = hrzn::intersect(*to, from);
+		Area area = hrzn::intersect(*to, from);
 		for (int y = area.y1; y <= area.y2; ++y)
 			for (int x = area.x1; x <= area.x2; ++x)
 				to->set(x, y, from.at(x, y));
@@ -160,8 +160,8 @@ namespace hrzn {
 	}
 
 	template <typename T>
-	void fill(IMatrix<T>* mat, const Rect area, const T& fill_obj) {
-		Rect fill_area = hrzn::intersect(*mat, area);
+	void fill(IMatrix<T>* mat, const Area area, const T& fill_obj) {
+		Area fill_area = hrzn::intersect(*mat, area);
 		for (int y = fill_area.y1; y <= fill_area.y2; ++y)
 			for (int x = fill_area.x1; x <= fill_area.x2; ++x)
 				mat->set(x, y, fill_obj);
@@ -169,7 +169,7 @@ namespace hrzn {
 
 	template <typename T>
 	void maskfill(IMatrix<T>* mat, const IMatrix<bool>& mask, const T& fill_obj) {
-		Rect fill_area = hrzn::intersect(*mat, mask);
+		Area fill_area = hrzn::intersect(*mat, mask);
 		for (int y = fill_area.y1; y <= fill_area.y2; ++y)
 			for (int x = fill_area.x1; x <= fill_area.x2; ++x)
 				if (mask.at(x, y)) 
@@ -178,7 +178,7 @@ namespace hrzn {
 
 	template <typename T>
 	void floodFillArea(hPoint start, IMatrix<T>* region, IMatrix<bool>* result, bool edge = false, bool use8 = false) {
-		Rect area = hrzn::intersect(*region, *result);
+		Area area = hrzn::intersect(*region, *result);
 		result->set(start, true);
 
 		for (int i = 0; i < (use8 ? 8 : 4); ++i) {
@@ -194,7 +194,7 @@ namespace hrzn {
 	}
 
 	void cellularAutomata(IMatrix<bool>* mask, int birth_rate, bool wrap_position) {
-		MatrixContainer<int> neighbor_counts((Rect)(*mask), 0);
+		MatrixContainer<int> neighbor_counts((Area)(*mask), 0);
 		for (auto cell : mask->region()) {
 			int n_count = 0;
 			for (const auto& dir : neighborhood8) {

--- a/include/hrzn/utility.h
+++ b/include/hrzn/utility.h
@@ -147,7 +147,7 @@ namespace hrzn {
 		Rect area = hrzn::intersect(*to, from);
 		for (int y = area.y1; y <= area.y2; ++y)
 			for (int x = area.x1; x <= area.x2; ++x)
-				to->at(x, y) = from.at(x, y);
+				to->set(x, y, from.at(x, y));
 	}
 
 	template <typename Ta, typename Tb>
@@ -155,7 +155,7 @@ namespace hrzn {
 		MatrixContainer<Ta> dup(mat);
 		for (int y = mat.y1; y <= mat.y2; ++y)
 			for (int x = mat.x1; x <= mat.x2; ++x)
-				dup.at(x, y) = cast(mat.at(x, y));
+				dup.set(x, y, cast(mat.at(x, y)));
 		return dup;
 	}
 
@@ -164,7 +164,7 @@ namespace hrzn {
 		Rect fill_area = hrzn::intersect(*mat, area);
 		for (int y = fill_area.y1; y <= fill_area.y2; ++y)
 			for (int x = fill_area.x1; x <= fill_area.x2; ++x)
-				mat->at(x, y) = fill_obj;
+				mat->set(x, y, fill_obj);
 	}
 
 	template <typename T>
@@ -172,13 +172,14 @@ namespace hrzn {
 		Rect fill_area = hrzn::intersect(*mat, mask);
 		for (int y = fill_area.y1; y <= fill_area.y2; ++y)
 			for (int x = fill_area.x1; x <= fill_area.x2; ++x)
-				if (mask.at(x, y)) mat.at(x, y) = fill_obj;
+				if (mask.at(x, y)) 
+					mat.set(x, y, fill_obj);
 	}
 
 	template <typename T>
 	void floodFillArea(hPoint start, IMatrix<T>* region, IMatrix<bool>* result, bool edge = false, bool use8 = false) {
 		Rect area = hrzn::intersect(*region, *result);
-		result->at(start) = true;
+		result->set(start, true);
 
 		for (int i = 0; i < (use8 ? 8 : 4); ++i) {
 			hPoint pos = start + (use8 ? neighborhood8 : neighborhood4)[i];
@@ -186,7 +187,7 @@ namespace hrzn {
 				if (region->at(pos) == region->at(start))
 					hrzn::floodFillArea(pos, region, result, edge, use8);
 				else if (edge)
-					result->at(pos) = true;
+					result->set(pos.x, true);
 			}
 		}
 
@@ -206,17 +207,17 @@ namespace hrzn {
 				if (mask->at(pos))
 					++n_count;
 			}
-			neighbor_counts.at(cell) = n_count;
+			neighbor_counts.set((hPoint)cell, n_count);
 		}
 		for (auto cell : mask->region())
-			*cell = neighbor_counts.at(cell) >= birth_rate;
+			mask->set((hPoint)cell, neighbor_counts.at(cell) >= birth_rate);
 	}
 
 	template <typename T>
 	void scatter(IMatrix<T>* mat, T val, double threshold) {
 		for (auto i : mat->region()) {
 			if (((double)std::rand() / (double)RAND_MAX) > threshold)
-				*i = val;
+				mat->set((hPoint)i, val);
 		}
 	}
 


### PR DESCRIPTION
* Renamed Rect and Iterable Rect to Area and Iterable Area
* Added a MatrixMask class derived from IMatrix<bool>.  Added bitwise operations for IMatrix<bool> objects to make processing masks easier.
* Added a set method to the IMatrix interface to replace setting values by lvalue. All utility methods now use this. A MatrixMask value cannot be set by lvalue as it returns a reference to a dummy member.